### PR TITLE
fix: Add npm ci to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Publish
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
This commit further refines the deployment workflow to resolve a persistent `npx` execution error.

The fix adds an `npm ci` step after setting up Node.js. This ensures that the exact versions of all project dependencies, including Wrangler, are installed from the `package-lock.json` file. This should create a more stable and predictable environment for the `cloudflare/wrangler-action`, preventing execution failures.