### PR TITLE
feat: Return JSON response from worker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,16 @@
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		return new Response('Hello World!');
+		const data = {
+			message: 'Hello World!',
+			source: 'Cloudflare Worker',
+			timestamp: new Date().toISOString(),
+		};
+
+		return new Response(JSON.stringify(data), {
+			headers: {
+				'content-type': 'application/json;charset=UTF-8',
+			},
+		});
 	},
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
This commit updates the Cloudflare Worker's fetch handler to return a JSON object instead of a plain text response.

The response now includes a message, source, and timestamp, and the `Content-Type` header is correctly set to `application/json;charset=UTF-8`.